### PR TITLE
chore: pin revm to tag v98-mantle-arsia.1 (Arsia hotfix)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,8 +56,8 @@ op-alloy = { git = "https://github.com/mantle-xyz/op-alloy", tag = "v2.2.0", def
 ] }
 
 # revm
-revm = { git = "https://github.com/mantle-xyz/revm", branch = "fix/op-revm-bvm-eth-deposit-cold-reset", default-features = false }
-op-revm = { git = "https://github.com/mantle-xyz/revm", branch = "fix/op-revm-bvm-eth-deposit-cold-reset", default-features = false }
+revm = { git = "https://github.com/mantle-xyz/revm", tag = "v98-mantle-arsia.1", default-features = false }
+op-revm = { git = "https://github.com/mantle-xyz/revm", tag = "v98-mantle-arsia.1", default-features = false }
 
 # misc
 auto_impl = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,8 +56,8 @@ op-alloy = { git = "https://github.com/mantle-xyz/op-alloy", tag = "v2.2.0", def
 ] }
 
 # revm
-revm = { git = "https://github.com/mantle-xyz/revm", tag = "v2.2.2", default-features = false }
-op-revm = { git = "https://github.com/mantle-xyz/revm", tag = "v2.2.2", default-features = false }
+revm = { git = "https://github.com/mantle-xyz/revm", branch = "fix/op-revm-bvm-eth-deposit-cold-reset", default-features = false }
+op-revm = { git = "https://github.com/mantle-xyz/revm", branch = "fix/op-revm-bvm-eth-deposit-cold-reset", default-features = false }
 
 # misc
 auto_impl = "1"


### PR DESCRIPTION
Repoint revm/op-revm from the fix branch to the released revm tag `v98-mantle-arsia.1` (revm PR #27 merged, commit c4a5004b). No functional change to alloy-evm/alloy-op-evm — only makes the revm dependency immutable for the reth `v1.9.3-mantle-arsia.2` release. `cargo check` green.